### PR TITLE
Fixed typos in usage. Created v2 of AngleCheckScannerUndo that uses a…

### DIFF
--- a/src/main/java/num110_at_gmail_dot_com/malishchak/N3Queens.java
+++ b/src/main/java/num110_at_gmail_dot_com/malishchak/N3Queens.java
@@ -16,8 +16,8 @@ public class N3Queens {
     public static String m_Usage = "Usage: ./N3Queens -n <NumberOfQueens> [-size <board size>]\n" +
                                    "\tGenerates a solution for the N-Queens problem where n\n" +
                                    "\tnumber of queens are placed on a NxN size chess board\n" +
-                                   "\tsuch that no two queens can attach one another.\n" +
-                                   "\tAdditionally, no three queens may be places such that\n" +
+                                   "\tsuch that no two queens can attack one another.\n" +
+                                   "\tAdditionally, no three queens may be placed such that\n" +
                                    "\tthey form a straight line at any angle, measured\n" +
                                    "\tthrough the center of their square.\n" +
                                    "\n" +


### PR DESCRIPTION
… HashMap to track X-values threatened by Queens already placed with the same X-value.

Significant performance improvements observed over v1. V1 Time for 18-18x18 was 9718ms, 19-19x19 was 29103ms, 20-20x20 was 154429ms. Estimated performance improvement is ~53-54%.

Some Single-Threaded Benchmarks on Windows 10 w/ i7-4890HQ @ 2.80 Ghz:

===RUN SUMMARY===
TARGET: 18 Queens. BOARD: 18x18.
ALGORITHM: "AngleCheckScannerUndo." VERSION: 2.
RESULT: Success.
RUNTIME: 4544ms.

===RUN SUMMARY===
TARGET: 19 Queens. BOARD: 19x19.
ALGORITHM: "AngleCheckScannerUndo." VERSION: 2.
RESULT: Success.
RUNTIME: 13407ms.


===RUN SUMMARY===
TARGET: 20 Queens. BOARD: 20x20.
ALGORITHM: "AngleCheckScannerUndo." VERSION: 2.
RESULT: Success.
RUNTIME: 71182ms.
